### PR TITLE
home/marcin/firefox: transparent tab bar and navigation bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Based on [Misterio77's nix-starter-configs](https://github.com/Misterio77/nix-st
 
 **Highlights:**
 - An attempt of declaratively configuring KDE, including the desktop layout ([module](modules/home-manager/kde.nix), [usage](home/marcin/common/optional/desktop/kde.nix))
-- Force blur on Wayland (WIP, taj-ny/nix-config#29)
+- Force blur on Wayland
 
 # Installation
 ```bash

--- a/home/marcin/common/optional/desktop/kde.nix
+++ b/home/marcin/common/optional/desktop/kde.nix
@@ -142,6 +142,22 @@ in
         };
       };
 
+      # KWin doesn't like rule names that aren't a number
+      # TODO This should be moved into a module
+      kwinrulesrc = {
+        "1" = {
+          Description = "Application settings for firefox";
+          forceblur = true;
+          forceblurrule = 2;
+          wmclass = "firefox";
+        };
+
+        General = {
+          count = 1;
+          rules = "1"; # Rule names separated by a comma (1,2)
+        };
+      };
+
       plasmanotifyrc.Notifications.LowPriorityHistory = true;
     };
   };

--- a/home/marcin/common/optional/programs/web-browsers/firefox.nix
+++ b/home/marcin/common/optional/programs/web-browsers/firefox.nix
@@ -187,13 +187,14 @@ in
             background-color: rgb(25, 25, 25) !important;
         }
 
+        #nav-bar,
         .tab-background:is([selected], [multiselected]) {
-            background-color: rgba(30, 30, 30, 0.75) !important;
+            background-color: transparent !important;
         }
 
         #TabsToolbar #firefox-view-button:hover:not([open]) > .toolbarbutton-icon,
         .tabbrowser-tab:hover > .tab-stack > .tab-background:not([selected], [multiselected]) {
-            background-color: rgba(35, 35, 35, 0.75) !important;
+            background-color: transparent !important;
         }
       '';
     };

--- a/home/marcin/common/optional/programs/web-browsers/firefox.nix
+++ b/home/marcin/common/optional/programs/web-browsers/firefox.nix
@@ -203,7 +203,7 @@ in
   home = {
     file.".mozilla/firefox/main/chrome/firefox-ui-fix".source = inputs.firefox-ui-fix;
     packages = [
-      (pkgs.patchDesktop firefox "firefox" "^Exec=firefox" "Exec=GDK_BACKEND=x11 firefox")
+      (pkgs.patchDesktop firefox "firefox" "^Exec=firefox" "Exec=MOZ_ENABLE_WAYLAND=1 firefox")
     ];
   };
 }

--- a/home/marcin/common/optional/programs/web-browsers/firefox.nix
+++ b/home/marcin/common/optional/programs/web-browsers/firefox.nix
@@ -202,7 +202,7 @@ in
   home = {
     file.".mozilla/firefox/main/chrome/firefox-ui-fix".source = inputs.firefox-ui-fix;
     packages = [
-      (pkgs.patchDesktop firefox "firefox" "^Exec=firefox" "Exec=MOZ_ENABLE_WAYLAND=1 firefox")
+      (pkgs.patchDesktop firefox "firefox" "^Exec=firefox" "Exec=GDK_BACKEND=x11 firefox")
     ];
   };
 }

--- a/home/marcin/common/optional/programs/web-browsers/firefox.nix
+++ b/home/marcin/common/optional/programs/web-browsers/firefox.nix
@@ -52,7 +52,6 @@ in
 
     profiles.main = {
       extraConfig = builtins.readFile "${inputs.firefox-ui-fix}/user.js";
-      userChrome = "@import url(\"firefox-ui-fix/userChrome.css\")";
       userContent = "@import url(\"firefox-ui-fix/userContent.css\")";
 
       extensions = with inputs.firefox-addons.packages.${pkgs.system}; [
@@ -168,6 +167,35 @@ in
         "network.trr.mode" = 3;
         "widget.use-xdg-desktop-portal.file-picker" = 1;
       };
+
+      userChrome = ''
+        @import url("firefox-ui-fix/userChrome.css");
+
+        html, #urlbar-background {
+            background-color: rgba(25, 25, 25, 0.5) !important;
+        }
+
+        toolbar, toolbox {
+            background-color: transparent !important;
+        }
+
+        #nav-bar {
+            box-shadow: unset !important;
+        }
+
+        #urlbar[focused=true] {
+            background-color: rgb(25, 25, 25) !important;
+        }
+
+        .tab-background:is([selected], [multiselected]) {
+            background-color: rgba(30, 30, 30, 0.75) !important;
+        }
+
+        #TabsToolbar #firefox-view-button:hover:not([open]) > .toolbarbutton-icon,
+        .tabbrowser-tab:hover > .tab-stack > .tab-background:not([selected], [multiselected]) {
+            background-color: rgba(35, 35, 35, 0.75) !important;
+        }
+      '';
     };
   };
 


### PR DESCRIPTION
Before:
![image](https://github.com/taj-ny/nix-config/assets/79316397/1063260c-48a9-4bfb-9c28-63f6695a53d1)

After:
![image](https://github.com/taj-ny/nix-config/assets/79316397/22a81a7a-9a16-46b2-b043-8f6f36fcc8f5)
